### PR TITLE
Use a Breadth-first search (BFS) algorithm in order to crawl

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,11 +21,11 @@
 */
 
 // This is our starting point. Change this to whatever URL you want.
-$start = "";
+$start = "http://www.google.com";
 
 // Our 2 global arrays containing our links to be crawled.
 $already_crawled = array();
-$crawling = array();
+$queue = new SplQueue();
 
 function get_details($url) {
 
@@ -66,53 +66,56 @@ function get_details($url) {
 function follow_links($url) {
 	// Give our function access to our crawl arrays.
 	global $already_crawled;
-	global $crawling;
+	global $queue;
 	// The array that we pass to stream_context_create() to modify our User Agent.
 	$options = array('http'=>array('method'=>"GET", 'headers'=>"User-Agent: howBot/0.1\n"));
 	// Create the stream context.
 	$context = stream_context_create($options);
 	// Create a new instance of PHP's DOMDocument class.
 	$doc = new DOMDocument();
-	// Use file_get_contents() to download the page, pass the output of file_get_contents()
-	// to PHP's DOMDocument class.
-	@$doc->loadHTML(@file_get_contents($url, false, $context));
-	// Create an array of all of the links we find on the page.
-	$linklist = $doc->getElementsByTagName("a");
-	// Loop through all of the links we find.
-	foreach ($linklist as $link) {
-		$l =  $link->getAttribute("href");
-		// Process all of the links we find. This is covered in part 2 and part 3 of the video series.
-		if (substr($l, 0, 1) == "/" && substr($l, 0, 2) != "//") {
-			$l = parse_url($url)["scheme"]."://".parse_url($url)["host"].$l;
-		} else if (substr($l, 0, 2) == "//") {
-			$l = parse_url($url)["scheme"].":".$l;
-		} else if (substr($l, 0, 2) == "./") {
-			$l = parse_url($url)["scheme"]."://".parse_url($url)["host"].dirname(parse_url($url)["path"]).substr($l, 1);
-		} else if (substr($l, 0, 1) == "#") {
-			$l = parse_url($url)["scheme"]."://".parse_url($url)["host"].parse_url($url)["path"].$l;
-		} else if (substr($l, 0, 3) == "../") {
-			$l = parse_url($url)["scheme"]."://".parse_url($url)["host"]."/".$l;
-		} else if (substr($l, 0, 11) == "javascript:") {
-			continue;
-		} else if (substr($l, 0, 5) != "https" && substr($l, 0, 4) != "http") {
-			$l = parse_url($url)["scheme"]."://".parse_url($url)["host"]."/".$l;
-		}
-		// If the link isn't already in our crawl array add it, otherwise ignore it.
-		if (!in_array($l, $already_crawled)) {
-				$already_crawled[] = $l;
-				$crawling[] = $l;
-				// Output the page title, descriptions, keywords and URL. This output is
-				// piped off to an external file using the command line.
-				echo get_details($l)."\n";
-		}
 
-	}
-	// Remove an item from the array after we have crawled it.
-	// This prevents infinitely crawling the same page.
-	array_shift($crawling);
-	// Follow each link in the crawling array.
-	foreach ($crawling as $site) {
-		follow_links($site);
+	$queue->enqueue($url);
+	echo get_details($url)."\n";
+	$already_crawled[] = $url;
+
+	while (!$queue->isEmpty()) {
+
+		$current_url = $queue->dequeue();
+
+		// Use file_get_contents() to download the page, pass the output of file_get_contents()
+		// to PHP's DOMDocument class.
+		@$doc->loadHTML(@file_get_contents($current_url, false, $context));
+		// Create an array of all of the links we find on the page.
+		$linklist = $doc->getElementsByTagName("a");
+		// Loop through all of the links we find.
+		foreach ($linklist as $link) {
+			$l =  $link->getAttribute("href");
+			// Process all of the links we find. This is covered in part 2 and part 3 of the video series.
+			if (substr($l, 0, 1) == "/" && substr($l, 0, 2) != "//") {
+				$l = parse_url($current_url)["scheme"]."://".parse_url($current_url)["host"].$l;
+			} else if (substr($l, 0, 2) == "//") {
+				$l = parse_url($current_url)["scheme"].":".$l;
+			} else if (substr($l, 0, 2) == "./") {
+				$l = parse_url($current_url)["scheme"]."://".parse_url($current_url)["host"].dirname(parse_url($current_url)["path"]).substr($l, 1);
+			} else if (substr($l, 0, 1) == "#") {
+				$l = parse_url($current_url)["scheme"]."://".parse_url($current_url)["host"].parse_url($current_url)["path"].$l;
+			} else if (substr($l, 0, 3) == "../") {
+				$l = parse_url($current_url)["scheme"]."://".parse_url($current_url)["host"]."/".$l;
+			} else if (substr($l, 0, 11) == "javascript:") {
+				continue;
+			} else if (substr($l, 0, 5) != "https" && substr($l, 0, 4) != "http") {
+				$l = parse_url($current_url)["scheme"]."://".parse_url($current_url)["host"]."/".$l;
+			}
+			// If the link isn't already in our crawl array add it, otherwise ignore it.
+			if (!in_array($l, $already_crawled)) {
+					$already_crawled[] = $l;
+					$queue->enqueue($l);
+					// Output the page title, descriptions, keywords and URL. This output is
+					// piped off to an external file using the command line.
+					echo get_details($l)."\n";
+			}
+
+		}
 	}
 
 }


### PR DESCRIPTION
Instead of using a recursive function and an array to keep track of the websites which need to be crawled, now it uses a queue in an iterative fashion. There seemed to be a bug in previous version where an item was removed from the array before your links were extracted.